### PR TITLE
Change DbParam to a struct tuple

### DIFF
--- a/src/Donald/Command.fs
+++ b/src/Donald/Command.fs
@@ -13,9 +13,9 @@ let assignDbParams (cmd : IDbCommand) (dbParams : DbParam list) =
     dbParams
     |> Seq.iter (fun param ->
         let p = cmd.CreateParameter()        
-        p.ParameterName <- param.Name
+        p.ParameterName <- (dbpName param)
         
-        match param.Value with
+        match dbpValue param with
         | Null -> 
             p.Value <- DBNull.Value
 
@@ -89,9 +89,9 @@ let clearParameters (cmd : IDbCommand) =
 
 /// DbParam constructor
 let newParam (name : string) (value : SqlType) =
-    { Name = name; Value = value }
-   
-/// Create a new IDbCommand  
+    struct (name, value)
+
+/// Create a new IDbCommand
 let newIDbCommand (commandType : CommandType) (sql : string) (tran : IDbTransaction) =
     let cmd = tran.Connection.CreateCommand()
     cmd.CommandType <- commandType

--- a/src/Donald/Core.fs
+++ b/src/Donald/Core.fs
@@ -35,10 +35,10 @@ type SqlType =
     | Bytes          of Byte[]
 
 /// Specifies an input parameter for an IDbCommand
-[<Struct>]
-type DbParam = 
-    { 
-        Name : String
-        Value : SqlType
-    }
+type DbParam = (struct (string * SqlType))
 
+/// Extracts first element Name of DbParam struct tuple
+let dbpName param = match param with | struct (x, _) -> x
+
+/// Extracts second element Value of DbParam struct tuple
+let dbpValue param = match param with | struct (_, x) -> x


### PR DESCRIPTION
So, F# 4.1, back in 2017 I think(?), introduced struct tuples. I actually think that using the struct tuples in place of the DbParam struct brings a much smoother user experience. Just look at the changed version of your Tests to see examples:

Old:

```fsharp
exec
    "UPDATE author SET full_name = @full_name WHERE author_id = @author_id"
    [ 
        newParam "author_id" (SqlType.Int authorId)
        newParam "full_name" (SqlType.String fullName)
    ]
    conn
```

New:

```fsharp
exec
    "UPDATE author SET full_name = @full_name WHERE author_id = @author_id"
    [ 
        "author_id", SqlType.Int authorId
        "full_name", SqlType.String fullName
    ]
    conn
```

We have one less word to write, use the more common list-of-tuples style of key-value pairs, and as a result, have no need to wrap parentheses around the value expressions.

The only caveat is that now, if you aren't directly supplying the list to one of those functions, then you need to either explicitly mark the data type of the list...

```fsharp
let authorParams : DbParam list list = 
    [
        [ "full_name", SqlType.String "Bugs Bunny" ]
        [ "full_name", SqlType.String "Donald Duck" ]
    ]                
execMany
    "INSERT INTO author (full_name) VALUES (@full_name);"                
    authorParams
    conn
```

...or explicitly cast the first entry to force an implicit cast on the other entries.

```fsharp
let authorParams = 
    [
        [ struct ("full_name", SqlType.String "Bugs Bunny") ]
        [ "full_name", SqlType.String "Donald Duck" ]
    ]                
execMany
    "INSERT INTO author (full_name) VALUES (@full_name);"                
    authorParams
    conn
```

While the struct record approach makes it easier to get the Name or Value of the DbParam, the vast majority of the time, people are going to be creating DbParams in lists to be passed into Donald functions, not extracting values from them. As such, I think it makes Donald easier to use this way.

Now, I've also refactored `newParam` to return a struct tuple, but, at this point, it would only exist for the sake of backward compatibility. I don't know if you would want it to be marked with an `Obsolete` attribute in that case, or if you would want to elevate the major version of the repo and discard `newParam` completely (though that seems a little extreme).

Let me know what you think. Thanks again for making such a delightful library!

