### PR TITLE
Added support for setting Command timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,13 @@ tran.TryRollback()
 
 ## Command Builder
 
-At the core of Donald is a computation expression for building `IDbCommand` instances. It exposes four modification points:
+At the core of Donald is a computation expression for building `IDbCommand` instances. It exposes five modification points:
 
 1. `cmdText` - SQL statement you intend to execute (default: `String.empty`).
 2. `cmdParam` - Input parameters for your statement (default: `[]`). 
 3. `cmdType` - Type of command you want to execute (default: `CommandType.Text`) 
 4. `cmdTran` - Transaction to assign to command.
+5. `cmdTimeout` - The maximum time a command can run for (default: underlying DbCommand default, usually 30 seconds)
 
 ## Execution Model
 

--- a/src/Donald/CommandBuilder.fs
+++ b/src/Donald/CommandBuilder.fs
@@ -1,23 +1,26 @@
 ﻿[<AutoOpen>]
 module Donald.CommandBuilder
 
+open System
 open System.Data
 
 type CommandSpec<'a> = 
     {
-        Connection  : IDbConnection
-        Transaction : IDbTransaction option
-        CommandType : CommandType
-        Statement   : string 
-        Param       : RawDbParams
+        Connection     : IDbConnection
+        Transaction    : IDbTransaction option
+        CommandType    : CommandType
+        CommandTimeout : int option
+        Statement      : string 
+        Param          : RawDbParams
     }
     static member Create (conn : IDbConnection) = 
         {
-            Connection  = conn
-            Transaction = None
-            CommandType = CommandType.Text
-            Statement   = ""
-            Param      = []
+            Connection     = conn
+            Transaction    = None
+            CommandType    = CommandType.Text
+            CommandTimeout = None
+            Statement      = ""
+            Param          = []
         }
 
 type CommandBuilder<'a>(conn : IDbConnection) =
@@ -27,12 +30,12 @@ type CommandBuilder<'a>(conn : IDbConnection) =
         let param = DbParams.create spec.Param
         match spec.Transaction with 
         | Some tran -> 
-            tran.NewCommand(spec.CommandType, spec.Statement)
+            tran.NewCommand(spec.CommandType, spec.Statement, spec.CommandTimeout)
                 .SetDbParams(param)
         
         | None ->
             spec.Connection
-                .NewCommand(spec.CommandType, spec.Statement)
+                .NewCommand(spec.CommandType, spec.Statement, spec.CommandTimeout)
                 .SetDbParams(param)
 
     [<CustomOperation("cmdParam")>]
@@ -50,5 +53,9 @@ type CommandBuilder<'a>(conn : IDbConnection) =
     [<CustomOperation("cmdType")>]
     member _.CommandType (spec : CommandSpec<'a>, commandType : CommandType) =
         { spec with CommandType = commandType }
+    
+    [<CustomOperation("cmdTimeout")>]
+    member _.CommandTimeout (spec : CommandSpec<'a>, timeout : TimeSpan) =
+        { spec with CommandTimeout = Some <| int timeout.TotalSeconds }
 
 let dbCommand<'a> (conn : IDbConnection) = CommandBuilder<'a>(conn)

--- a/src/Donald/Connection.fs
+++ b/src/Donald/Connection.fs
@@ -4,10 +4,11 @@ module Donald.Conection
 open System.Data 
 
 type IDbConnection with
-    member internal this.NewCommand(commandType : CommandType, sql : string) =
+    member internal this.NewCommand(commandType : CommandType, sql : string, commandTimeout : int option) =
         let cmd = this.CreateCommand()
         cmd.CommandType <- commandType
         cmd.CommandText <- sql
+        commandTimeout |> Option.iter (fun timeout -> cmd.CommandTimeout <- timeout)
         cmd
 
     member internal this.TryOpenConnection()  =        
@@ -23,5 +24,3 @@ type IDbConnection with
             this.BeginTransaction()
         with         
         | ex -> raise (CouldNotBeginTransactionError ex)
- 
-

--- a/src/Donald/Transaction.fs
+++ b/src/Donald/Transaction.fs
@@ -5,13 +5,13 @@ open System.Data
 open System.Data.Common
 
 type IDbTransaction with
-    member internal this.NewCommand(commandType : CommandType, sql : string) =
-        let cmd = this.Connection.NewCommand(commandType, sql)
-        cmd.Transaction <- this        
+    member internal this.NewCommand(commandType : CommandType, sql : string, commandTimeout : int option) =
+        let cmd = this.Connection.NewCommand(commandType, sql, commandTimeout)
+        cmd.Transaction <- this
         cmd
 
-    member internal this.NewDbCommand(commandType : CommandType, sql : string) =
-        this.NewCommand(commandType, sql) :?> DbCommand
+    member internal this.NewDbCommand(commandType : CommandType, sql : string, commandTimeout : int option) =
+        this.NewCommand(commandType, sql, commandTimeout) :?> DbCommand
 
     member this.TryRollback() =
         try        


### PR DESCRIPTION
I've got a couple of queries that take a long time to execute (they're crunching millions of rows), and I need to extend the command timeout.

This PR adds another custom operation to the `CommandBuilder` called `cmdTimeout` that allows you to set the timeout on a per-command basis.

Currently `cmdTimeout` takes a TimeSpan, because it makes what unit the timeout is defined in explicit, but I'm happy to change it to `int` "seconds", which is the type of the underlying DbCommand property that is being set.

I hope you don't mind the random out of the blue PR. The change was simple enough it seemed easier to just make it and send the PR than discuss it first :)